### PR TITLE
Handle case of multiple IP range, combination of CIDR and IP range

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ $ cat ips.txt | mapcidr -aggregate-approx
 
 In order to list CIDR blocks for given IP Range (**IPv4 | IPv6**), use the following command.
 ```
- $ mapcidr  -cl 192.168.0.1-192.168.0.255 -aggregate 
+ $ mapcidr  -cl 192.168.0.1-192.168.0.255 -aggregate
  OR
  $ echo 192.168.0.1-192.168.0.255 | mapcidr -aggregate
 ```

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -295,6 +295,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 
 	for cidr := range chancidr {
 
+		// Add IPs into ipRangeMap which are passed as input. Example - "192.168.0.0-192.168.0.5"
 		if strings.Contains(cidr, "-") {
 			options.IPRangeInput = true
 			var ipRange []net.IP
@@ -332,9 +333,8 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 			continue
 		}
 
-		// Add IPs which are passed as input. Example - "192.168.0.0-192.168.0.5"
+		// In case of coalesce/shuffle we need to know all the cidrs and aggregate them by calling the proper function
 		if options.Aggregate || options.Shuffle || hasSort || options.AggregateApprox || options.Count {
-			// In case of coalesce/shuffle we need to know all the cidrs and aggregate them by calling the proper function
 			_ = ranger.AddIPNet(pCidr)
 			allCidrs = append(allCidrs, pCidr)
 		} else {
@@ -384,7 +384,6 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 
 	// Aggregate all ips into the minimal subset possible
 	if options.Aggregate {
-
 		cCidrsIPV4, cCidrsIPV6 := mapcidr.CoalesceCIDRs(allCidrs)
 		for _, cidrIPV4 := range cCidrsIPV4 {
 			outputchan <- cidrIPV4.String()

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -282,13 +282,12 @@ func prepareIPsFromCidrFlagList(items []string) []string {
 func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 	defer wg.Done()
 	var (
-		allCidrs     []*net.IPNet
-		pCidr        *net.IPNet
-		ranger       *ipranger.IPRanger
-		err          error
-		hasSort      = options.SortAscending || options.SortDescending
-		ipRangeMap   = make(map[int][]net.IP)
-		iprangeCount int
+		allCidrs    []*net.IPNet
+		pCidr       *net.IPNet
+		ranger      *ipranger.IPRanger
+		err         error
+		hasSort     = options.SortAscending || options.SortDescending
+		ipRangeList = make([][]net.IP, 0)
 	)
 
 	ranger, _ = ipranger.New()
@@ -306,8 +305,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 			if len(ipRange)%2 == 1 {
 				gologger.Fatal().Msgf("IP range can not have more than 2 values.")
 			}
-			ipRangeMap[iprangeCount] = ipRange
-			iprangeCount++
+			ipRangeList = append(ipRangeList, ipRange)
 			continue
 		}
 		// if it's an ip turn it into a cidr
@@ -342,7 +340,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 		}
 	}
 	if options.IPRangeInput {
-		for _, ipRange := range ipRangeMap {
+		for _, ipRange := range ipRangeList {
 
 			cidrs, err := mapcidr.GetCIDRFromIPRange(ipRange[0], ipRange[1])
 			if err != nil {

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -71,8 +71,7 @@ func TestProcess(t *testing.T) {
 			outputchan: make(chan string),
 			options: Options{
 
-				FileCidr:     []string{"10.40.0.0", "10.40.0.5"},
-				IPRangeInput: true,
+				FileCidr: []string{"10.40.0.0-10.40.0.5"},
 			},
 			expectedOutput: []string{"10.40.0.0", "10.40.0.1", "10.40.0.2", "10.40.0.3", "10.40.0.4", "10.40.0.5"},
 		},
@@ -82,8 +81,7 @@ func TestProcess(t *testing.T) {
 			outputchan: make(chan string),
 			options: Options{
 
-				FileCidr:     []string{"2c0f:fec9::", "2c0f:fec9::3"},
-				IPRangeInput: true,
+				FileCidr: []string{"2c0f:fec9::-2c0f:fec9::3"},
 			},
 			expectedOutput: []string{"2c0f:fec9::", "2c0f:fec9::1", "2c0f:fec9::2", "2c0f:fec9::3"},
 		},
@@ -93,9 +91,8 @@ func TestProcess(t *testing.T) {
 			outputchan: make(chan string),
 			options: Options{
 
-				FileCidr:     []string{"10.40.0.1", "10.40.0.255"},
-				Aggregate:    true,
-				IPRangeInput: true,
+				FileCidr:  []string{"10.40.0.1-10.40.0.255"},
+				Aggregate: true,
 			},
 			expectedOutput: []string{"10.40.0.64/26", "10.40.0.32/27", "10.40.0.16/28", "10.40.0.8/29", "10.40.0.4/30", "10.40.0.2/31", "10.40.0.1/32", "10.40.0.128/25"},
 		},
@@ -105,9 +102,8 @@ func TestProcess(t *testing.T) {
 			outputchan: make(chan string),
 			options: Options{
 
-				FileCidr:     []string{"2c0f:fec9::", "2c0f:fed7:ffff:ffff:ffff:ffff:ffff:ffff"},
-				Aggregate:    true,
-				IPRangeInput: true,
+				FileCidr:  []string{"2c0f:fec9::-2c0f:fed7:ffff:ffff:ffff:ffff:ffff:ffff"},
+				Aggregate: true,
 			},
 			expectedOutput: []string{"2c0f:fecc::/30", "2c0f:feca::/31", "2c0f:fec9::/32", "2c0f:fed0::/29"},
 		},
@@ -117,9 +113,8 @@ func TestProcess(t *testing.T) {
 			outputchan: make(chan string),
 			options: Options{
 
-				FileCidr:     []string{"10.40.0.0", "10.40.0.255"},
-				Slices:       2,
-				IPRangeInput: true,
+				FileCidr: []string{"10.40.0.0-10.40.0.255"},
+				Slices:   2,
 			},
 			expectedOutput: []string{"10.40.0.0/25", "10.40.0.128/25"},
 		},
@@ -129,11 +124,47 @@ func TestProcess(t *testing.T) {
 			outputchan: make(chan string),
 			options: Options{
 
-				FileCidr:     []string{"10.40.0.0", "10.40.0.255"},
-				HostCount:    128,
-				IPRangeInput: true,
+				FileCidr:  []string{"10.40.0.0-10.40.0.255"},
+				HostCount: 128,
 			},
 			expectedOutput: []string{"10.40.0.0/25", "10.40.0.128/25"},
+		}, {
+			name:       "CombinationOneIPRangeAggregate",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:  []string{"166.8.0.0/16", "166.11.0.0/16", "166.9.0.0-166.10.255.255"},
+				Aggregate: true,
+			},
+			expectedOutput: []string{"166.8.0.0/14"},
+		}, {
+			name:       "CombinationMultipleIPRangeAggregate",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:  []string{"173.0.0.0/18", "173.0.64.0-173.0.127.255", "173.0.128.0/18", "173.0.192.0-173.0.255.255"},
+				Aggregate: true,
+			},
+			expectedOutput: []string{"173.0.0.0/16"},
+		},
+		{
+			name:       "CombinationOneIPRangeCount",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr: []string{"166.8.0.0/16", "166.11.0.0/16", "166.9.0.0-166.10.255.255"},
+				Count:    true,
+			},
+			expectedOutput: []string{"262144"},
+		}, {
+			name:       "MultipleIPRangeAggregate",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:  []string{"166.8.0.0-166.8.0.5", "166.8.0.5-166.8.0.255"},
+				Aggregate: true,
+			},
+			expectedOutput: []string{"166.8.0.0/24"},
 		},
 	}
 	var wg sync.WaitGroup


### PR DESCRIPTION
- Input may contain the multiple CIDRs and multiple IP ranges
  eg. `166.8.0.0/16,166.11.0.0/16,166.9.0.0-166.10.255.255`
- Handle the above input for arggregation, count, etc
- Move the string split logic from `main()` to `process()` function
- Add the new variable IPRangeMap which stores multiple IP range