### PR TITLE
Update sorting behaviour

### DIFF
--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -509,9 +509,6 @@ func getIPList(cidrs []*net.IPNet) []net.IP {
 			gologger.Fatal().Msgf("%s\n", err)
 		}
 		for ip := range ips {
-			if err != nil {
-				gologger.Fatal().Msgf("%s\n", err)
-			}
 			ipList = append(ipList, net.ParseIP(ip))
 		}
 	}

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -107,8 +107,8 @@ func ParseOptions() *Options {
 
 	// Miscellaneous
 	flagSet.CreateGroup("miscellaneous", "Miscellaneous",
-		flagSet.BoolVarP(&options.SortAscending, "sort", "s", false, "Sort input IPs/CIDRs in ascending order"),
-		flagSet.BoolVarP(&options.SortDescending, "sort-reverse", "sr", false, "Sort input IPs/CIDRs in descending order"),
+		flagSet.BoolVarP(&options.SortAscending, "sort", "s", false, "Sort input IPs in ascending order"),
+		flagSet.BoolVarP(&options.SortDescending, "sort-reverse", "sr", false, "Sort input IPs in descending order"),
 		flagSet.BoolVarP(&options.Shuffle, "shuffle-ip", "si", false, "Shuffle Input IPs in random order"),
 		flagSet.StringVarP(&options.ShufflePorts, "shuffle-port", "sp", "", "Shuffle Input IP:Port in random order"),
 	)
@@ -174,6 +174,10 @@ func (options *Options) validateOptions() error {
 	}
 	if options.FilterIP != nil && options.MatchIP != nil {
 		return errors.New("both match and filter mode specified")
+	}
+
+	if (options.SortAscending || options.SortDescending) && options.Aggregate {
+		return errors.New("can sort only IPs. sorting can't be used with aggregate")
 	}
 	return nil
 }
@@ -390,17 +394,18 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 	}
 
 	if hasSort {
+		ips := getIPList(allCidrs)
 		if options.SortDescending {
-			sort.Slice(allCidrs, func(i, j int) bool {
-				return bytes.Compare(allCidrs[j].IP, allCidrs[i].IP) < 0
+			sort.Slice(ips, func(i, j int) bool {
+				return bytes.Compare(ips[j], ips[i]) < 0
 			})
 		} else {
-			sort.Slice(allCidrs, func(i, j int) bool {
-				return bytes.Compare(allCidrs[i].IP, allCidrs[j].IP) < 0
+			sort.Slice(ips, func(i, j int) bool {
+				return bytes.Compare(ips[i], ips[j]) < 0
 			})
 		}
-		for _, cidr := range allCidrs {
-			outputchan <- cidr.String()
+		for _, ip := range ips {
+			outputchan <- ip.String()
 		}
 	}
 
@@ -493,4 +498,22 @@ func outputItems(f *os.File, items ...string) {
 			_, _ = f.WriteString(item + "\n")
 		}
 	}
+}
+
+// returns the list of expanded IPs of given CIDR list
+func getIPList(cidrs []*net.IPNet) []net.IP {
+	var ipList []net.IP
+	for _, cidr := range cidrs {
+		ips, err := mapcidr.IPAddressesAsStream(cidr.String())
+		if err != nil {
+			gologger.Fatal().Msgf("%s\n", err)
+		}
+		for ip := range ips {
+			if err != nil {
+				gologger.Fatal().Msgf("%s\n", err)
+			}
+			ipList = append(ipList, net.ParseIP(ip))
+		}
+	}
+	return ipList
 }

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -166,6 +166,60 @@ func TestProcess(t *testing.T) {
 				Aggregate: true,
 			},
 			expectedOutput: []string{"166.8.0.0/24"},
+		}, {
+			name:       "IPsSortAscending",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:      []string{"1.1.1.1", "8.8.8.8", "255.255.255.255", "2.2.2.2", "2.4.4.4", "2.4.3.2", "9.9.9.9"},
+				SortAscending: true,
+			},
+			expectedOutput: []string{"1.1.1.1", "2.2.2.2", "2.4.3.2", "2.4.4.4", "8.8.8.8", "9.9.9.9", "255.255.255.255"},
+		}, {
+			name:       "IPsSortDescending",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:       []string{"1.1.1.1", "255.255.255.255", "2.4.3.2", "2.2.2.2", "8.8.8.8", "2.4.4.4", "9.9.9.9"},
+				SortDescending: true,
+			},
+			expectedOutput: []string{"255.255.255.255", "9.9.9.9", "8.8.8.8", "2.4.4.4", "2.4.3.2", "2.2.2.2", "1.1.1.1"},
+		}, {
+			name:       "CIDRsIPSortAscending",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:      []string{"10.40.0.0/30"},
+				SortAscending: true,
+			},
+			expectedOutput: []string{"10.40.0.0", "10.40.0.1", "10.40.0.2", "10.40.0.3"},
+		}, {
+			name:       "CIDRsIPSortDescending",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:       []string{"10.40.1.0/30"},
+				SortDescending: true,
+			},
+			expectedOutput: []string{"10.40.1.3", "10.40.1.2", "10.40.1.1", "10.40.1.0"},
+		}, {
+			name:       "IPRangeIPSortAscending",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:      []string{"192.168.0.0-192.168.0.3"},
+				SortAscending: true,
+			},
+			expectedOutput: []string{"192.168.0.0", "192.168.0.1", "192.168.0.2", "192.168.0.3"},
+		}, {
+			name:       "IPRangeIIPSortDescending",
+			chancidr:   make(chan string),
+			outputchan: make(chan string),
+			options: Options{
+				FileCidr:       []string{"192.168.1.0-192.168.1.3"},
+				SortDescending: true,
+			},
+			expectedOutput: []string{"192.168.1.3", "192.168.1.2", "192.168.1.1", "192.168.1.0"},
 		},
 	}
 	var wg sync.WaitGroup


### PR DESCRIPTION
- Expand the CIDR then sort
- Before it was converting IPs to CIDR then sort.
- Add `getIPList()` which expands the CIDRs to IP for sorting